### PR TITLE
Add a package configuration for elm-review

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -9,16 +9,11 @@
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
-        "elm/bytes": "1.0.8 <= v < 2.0.0",
         "elm/core": "1.0.0 <= v < 2.0.0",
-        "elm/http": "2.0.0 <= v < 3.0.0",
-        "elm/json": "1.1.3 <= v < 2.0.0",
         "elm/regex": "1.0.0 <= v < 2.0.0",
-        "elm/time": "1.0.0 <= v < 2.0.0",
         "elmcraft/core-extra": "2.0.0 <= v < 3.0.0",
         "jfmengels/elm-review": "2.14.0 <= v < 3.0.0",
-        "jxxcarlson/elm-review-codeinstaller": "12.0.4 <= v < 13.0.0",
-        "mdgriffith/elm-ui": "1.1.8 <= v < 2.0.0"
+        "jxxcarlson/elm-review-codeinstaller": "12.0.4 <= v < 13.0.0"
     },
     "test-dependencies": {}
 }

--- a/review/elm.json
+++ b/review/elm.json
@@ -1,25 +1,29 @@
 {
     "type": "application",
     "source-directories": [
-        "src",
-        "../src"
+        "src"
     ],
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
             "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/project-metadata-utils": "1.0.2",
             "elm/regex": "1.0.0",
-            "elmcraft/core-extra": "2.0.0",
             "jfmengels/elm-review": "2.14.0",
-            "jxxcarlson/elm-review-codeinstaller": "12.0.1",
+            "jfmengels/elm-review-code-style": "1.1.4",
+            "jfmengels/elm-review-common": "1.3.3",
+            "jfmengels/elm-review-debug": "1.0.8",
+            "jfmengels/elm-review-documentation": "2.0.4",
+            "jfmengels/elm-review-simplify": "2.1.5",
+            "jfmengels/elm-review-unused": "1.2.3",
+            "sparksp/elm-review-forbidden-words": "1.0.1",
             "stil4m/elm-syntax": "7.3.3"
         },
         "indirect": {
             "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/json": "1.1.3",
             "elm/parser": "1.1.0",
-            "elm/project-metadata-utils": "1.0.2",
             "elm/random": "1.0.0",
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.3",
@@ -31,9 +35,7 @@
         }
     },
     "test-dependencies": {
-        "direct": {
-            "elm-explorations/test": "2.2.0"
-        },
+        "direct": {},
         "indirect": {}
     }
 }

--- a/review/src/ReviewConfig.elm
+++ b/review/src/ReviewConfig.elm
@@ -1,6 +1,5 @@
 module ReviewConfig exposing (config)
 
-
 {-| Do not rename the ReviewConfig module or the config function, because
 `elm-review` will look for these.
 
@@ -12,13 +11,56 @@ when inside the directory containing this file.
 
 -}
 
-import Review.Rule exposing (Rule)
-import RuleSest.Add
+import Docs.NoMissing exposing (exposedModules, onlyExposed)
+import Docs.ReviewAtDocs
+import Docs.ReviewLinksAndSections
+import Docs.UpToDateReadmeLinks
+import NoConfusingPrefixOperator
+import NoDebug.Log
+import NoDebug.TodoOrToString
+import NoExposingEverything
+import NoForbiddenWords
+import NoImportingEverything
+import NoMissingTypeAnnotation
+import NoMissingTypeAnnotationInLetIn
+import NoMissingTypeExpose
+import NoPrematureLetComputation
+import NoSimpleLetBody
+import NoUnused.CustomTypeConstructorArgs
+import NoUnused.CustomTypeConstructors
+import NoUnused.Dependencies
+import NoUnused.Exports
+import NoUnused.Parameters
+import NoUnused.Patterns
+import NoUnused.Variables
+import Review.Rule as Rule exposing (Rule)
+import Simplify
+
 
 config : List Rule
-config  = config1
-
-config1 = RuleSet.Add.magicLinkAuth "Jim Carlson" "jxxcarlson" "jxxcarlson@gmail.com"
-
-config2 = RuleSet.Add.pages [ ("QuotesRoute", "quotes"), ("QuotesRoute", "jokes") ]
-
+config =
+    [ Docs.ReviewAtDocs.rule
+    , Docs.NoMissing.rule { document = onlyExposed, from = exposedModules }
+    , Docs.ReviewLinksAndSections.rule
+    , Docs.UpToDateReadmeLinks.rule
+    , NoConfusingPrefixOperator.rule
+    , NoDebug.Log.rule
+    , NoDebug.TodoOrToString.rule
+        |> Rule.ignoreErrorsForDirectories [ "tests/" ]
+    , NoExposingEverything.rule
+    , NoForbiddenWords.rule [ "REPLACEME" ]
+    , NoImportingEverything.rule []
+    , NoMissingTypeAnnotation.rule
+    , NoMissingTypeAnnotationInLetIn.rule
+    , NoMissingTypeExpose.rule
+    , NoSimpleLetBody.rule
+    , NoPrematureLetComputation.rule
+    , NoUnused.CustomTypeConstructors.rule []
+    , NoUnused.CustomTypeConstructorArgs.rule
+    , NoUnused.Dependencies.rule
+    , NoUnused.Exports.rule
+    , NoUnused.Parameters.rule
+    , NoUnused.Patterns.rule
+    , NoUnused.Variables.rule
+    , Simplify.rule Simplify.defaults
+    ]

--- a/review/suppressed/NoMissingTypeAnnotation.json
+++ b/review/suppressed/NoMissingTypeAnnotation.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "automatically created by": "elm-review suppress",
+  "learn more": "elm-review suppress --help",
+  "suppressions": [
+    { "count": 5, "filePath": "src/RuleSet/Add.elm" }
+  ]
+}

--- a/review/suppressed/NoUnused.Dependencies.json
+++ b/review/suppressed/NoUnused.Dependencies.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "automatically created by": "elm-review suppress",
+  "learn more": "elm-review suppress --help",
+  "suppressions": [
+    { "count": 5, "filePath": "elm.json" }
+  ]
+}

--- a/review/suppressed/NoUnused.Dependencies.json
+++ b/review/suppressed/NoUnused.Dependencies.json
@@ -1,8 +1,0 @@
-{
-  "version": 1,
-  "automatically created by": "elm-review suppress",
-  "learn more": "elm-review suppress --help",
-  "suppressions": [
-    { "count": 5, "filePath": "elm.json" }
-  ]
-}

--- a/review/suppressed/NoUnused.Variables.json
+++ b/review/suppressed/NoUnused.Variables.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "automatically created by": "elm-review suppress",
+  "learn more": "elm-review suppress --help",
+  "suppressions": [
+    { "count": 3, "filePath": "src/RuleSet/Add.elm" }
+  ]
+}


### PR DESCRIPTION
The review configuration for this project was erased by having it be somewhat the same as `preview/`, but `review/` should (at least ideally) be for the sake of maintenance of the project itself. I'm re-introducing the default configuration brought by `elm-review new-package`. I hope it helps. I fixed a few of the issues, and suppressed the remaining. Feel free to disable (remove) the rules you disagree with, or to enable more in the future.

That said, there is no CI setup for this project, which could be good to have, otherwise PRs can introduce new errors without anyone noticing. I think you could copy a lot of the scripts available in `jxxcarlson/elm-review-codeinstaller` (created by `elm-review new-package`).